### PR TITLE
option to replace node's url parser

### DIFF
--- a/js/urlparser.js
+++ b/js/urlparser.js
@@ -916,3 +916,9 @@ Url.prototype._noPrependSlashHostEnders = makeAsciiTable(
 Url.prototype._autoEscapeMap = autoEscapeMap;
 
 module.exports = Url;
+
+Url.replace = function Url_replace() {
+    require.cache["url"] = {
+        exports: Url
+    };
+};

--- a/src/urlparser.js
+++ b/src/urlparser.js
@@ -1002,3 +1002,9 @@ Url.prototype._noPrependSlashHostEnders = makeAsciiTable(
 Url.prototype._autoEscapeMap = autoEscapeMap;
 
 module.exports = Url;
+
+Url.replace = function Url_replace() {
+    require.cache["url"] = {
+        exports: Url
+    };
+};

--- a/test/urlparser.js
+++ b/test/urlparser.js
@@ -222,6 +222,11 @@ describe("basic tests", function() {
 
     });
 
+    specify('replace node\'s url', function() {
+        Url.replace();
+        assert.equal(Url, require('url'));
+    });
+
     //Syntax errors
 });
 


### PR DESCRIPTION
closes #1

so you don't have to convince every module to use this, you can just tell devs to `require('fast-url-parser').replace()` in the beginning of their app and everything will be magically faster.

you might want to change the name or something. also, docs + blog post would be nice. 
