### PR TITLE
Explicitly list `punycode` as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,9 @@
         "email": "petka_antonov@hotmail.com",
         "url": "http://github.com/petkaantonov/"
     },
+    "dependencies": {
+        "punycode": "~1.3.0"
+    },
     "devDependencies": {
         "grunt": "~0.4.1",
         "grunt-contrib-jshint": "~0.6.4",


### PR DESCRIPTION
That way nothing breaks if Node ever removes [punycode.js](http://mths.be/punycode) from its core.
